### PR TITLE
Fixed S5 Extinguisher Texture

### DIFF
--- a/Mechtrauma/XML/Mechtrauma_Items.xml
+++ b/Mechtrauma/XML/Mechtrauma_Items.xml
@@ -151,8 +151,8 @@
       <RequiredSkill identifier="mechanical" level="20" />
       <RequiredItem identifier="aluminium" />      
     </Fabricate>
-    <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="0,0,64,64" origin="0.5,0.5" />
-    <Sprite texture="Content/Items/Tools/tools.png" depth="0.55" sourcerect="161,105,64,128" origin="0.5,0.5" />
+    <InventoryIcon texture="%ModDir%/Images/mechtrauma.png" sourcerect="0,131,43,69" origin="0.5,0.5" />
+    <Sprite texture="%ModDir%/Images/mechtrauma.png" depth="0.55" sourcerect="0,131,43,69" origin="0.5,0.5" />
     <Body width="15" height="50" density="5" />
     <Holdable slots="Any,RightHand,LeftHand" controlpose="true" aimpos="40,-20" handle1="-6,10" handle2="-10,40" msg="ItemMsgPickUpSelect" />
     <RepairTool extinguishamount="60.0" range="500" barrelpos="21,25" repairthroughholes="true" hititems="false">


### PR DESCRIPTION
Has been using a shrunken Fire Extinguisher texture, now replaced with the proper one from the mod page and on mechtrauma.png